### PR TITLE
Added DecodedSubjectAltNames, an accessor for SANs

### DIFF
--- a/lib/Crypt/X509.pm
+++ b/lib/Crypt/X509.pm
@@ -766,6 +766,58 @@ sub SubjectAltName {
     }
     return undef;
 }
+
+=head2 DecodedSubjectAltNames
+
+Returns a pointer to an array of strings containing all the alternative subject name
+extensions.
+
+Each such extension is represented as a decoded ASN.1 value, i.e. a pointer to a list
+of pointers to objects, each object having a single key with the type of the alternative
+name and a value specific to that type.
+
+Example return value:
+
+  [
+    [
+      {
+        'directoryName' => {
+          'rdnSequence' => [
+            [
+              {
+                'value' => { 'utf8String' => 'example' },
+                'type' => '2.5.4.3'
+              }
+            ]
+          ]
+        }
+      },
+      {
+        'dNSName' => 'example.com'
+      }
+    ]
+  ]
+
+=cut back
+
+sub DecodedSubjectAltNames {
+    my $self = shift;
+    my @sans = ();
+    my $exts = $self->{'tbsCertificate'}->{'extensions'};
+    foreach my $ext ( @{$exts} ) {
+        if ( $ext->{'extnID'} eq '2.5.29.17' ) { #OID for subjectAltName
+            my $parsSubjAlt = _init('SubjectAltName');
+            my $altnames = $parsSubjAlt->decode( $ext->{'extnValue'} );
+            if ( $parsSubjAlt->error ) {
+                $self->{'_error'} = $parsSubjAlt->error;
+                return undef;
+            }
+            push @sans, $altnames;
+        }
+    }
+    return \@sans;
+}
+
 #########################################################################
 # accessors - authorityCertIssuer
 #########################################################################

--- a/t/Crypt-X509.t
+++ b/t/Crypt-X509.t
@@ -1,6 +1,6 @@
 # Before `make install' is performed this script should be runnable with
 # `make test'. After `make install' it should work as `perl Crypt-X509.t'
-use Test::More tests => 68;
+use Test::More tests => 70;
 use Math::BigInt;
 BEGIN { use_ok('Crypt::X509') }
 
@@ -39,6 +39,7 @@ is( $decoded2->sig_algorithm,       "1.2.840.113549.1.1.5", "sig_algorithm" );
 is( length( $decoded2->pubkey ),    140,                    "Pubkey length" );
 is( length( $decoded2->signature ), 256,                    "Signature Length" );
 is( join( ',', @{ $decoded2->SubjectAltName } ), "rfc822Name=alexander.jung\@allianz.de", 'SubjectAltName parsed' );
+is_deeply( $decoded2->DecodedSubjectAltNames, [[{rfc822Name => 'alexander.jung@allianz.de'}]], 'DecodedSubjectAltName parsed' );
 
 $cert = loadcert('t/aj2.cer');
 $decoded3 = Crypt::X509->new( cert => $cert );
@@ -87,6 +88,10 @@ is( $mon + 1,            3,          "generalTime month" );
 is( $year + 1900,        2005,       "generalTime year" );
 is( join( ',', @{ $decoded->Issuer } ), 'C=DE,O=Deutsche Telekom AG,nameDistinguisher=1,CN=NKS CA 6:PN', 'Issuer for telesec' );
 is( join( ',', @{ $decoded->Subject } ), 'C=DE,nameDistinguisher=2,CN=Schefe, Jan', 'Subject for telesec' );
+is_deeply( $decoded->DecodedSubjectAltNames, [[
+    {otherName => {value => "0\x111\x0f0\x0d\x06\x03U\x04\x04\x14\x06Schefe", type => '0.2.262.1.10.3.0'}},
+    {otherName => {value => "0\x0e1\x0c0\x0a\x06\x03U\x04*\x14\x03Jan", type => '0.2.262.1.10.3.0'}}]],
+    'DecodedSubjectAltNames for telesec');
 
 $cert = loadcert('t/dsacert.der');
 $decoded = Crypt::X509->new( cert => $cert );


### PR DESCRIPTION
This can be used to retrieve all the SANs in the certificate in their proper decoded form.

The plan is to use this to fix https://github.com/openxpki/openxpki/issues/747.